### PR TITLE
Fix so settings only get updated on save

### DIFF
--- a/src/app/apps/quap/components/settings-view/settings-view.component.ts
+++ b/src/app/apps/quap/components/settings-view/settings-view.component.ts
@@ -42,10 +42,6 @@ export class SettingsViewComponent implements OnInit, DialogController {
   updateShareData(value: boolean): void {
     this.wasModified = true;
     this.settings.shareData = value;
-
-    this.apiService.patch(`groups/${(this.groupFacade.getCurrentGroupSnapshot().id)}/quap/questionnaire`, {
-      allow_access: value,
-    }).subscribe();
   }
 
   close(): void {
@@ -68,6 +64,9 @@ export class SettingsViewComponent implements OnInit, DialogController {
 
   save(): void {
     this.quapSettingsService.setSettings(this.settings);
+    this.apiService.patch(`groups/${(this.groupFacade.getCurrentGroupSnapshot().id)}/quap/questionnaire`, {
+      allow_access: this.settings.shareData,
+    }).subscribe();
     this.dialogService.forceClose();
   }
 


### PR DESCRIPTION
ATM the Setting share Data is adjusted when the switch is toggled. Adjust it so that the setting is only adjusten when you hit the ✅