### PR TITLE
HC/288: Fixed quap aspects dialog

### DIFF
--- a/src/app/apps/quap/components/graph-views/canton-graph-view/canton-graph-view.component.html
+++ b/src/app/apps/quap/components/graph-views/canton-graph-view/canton-graph-view.component.html
@@ -4,7 +4,7 @@
 
 <div *ngIf="aspects.length > 0" class="graph-container">
   <svg width="1760"  viewBox="0 0 3520 1768" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-    <foreignObject *ngFor="let aspect of aspects; let i = index" [attr.x]="aspectMapping[aspect.id].x" [attr.y]="aspectMapping[aspect.id].y" width="320" height="160" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" (click)="onAspectClick(i)">
+    <foreignObject *ngFor="let aspect of aspects" [attr.x]="aspectMapping[aspect.id].x" [attr.y]="aspectMapping[aspect.id].y" width="320" height="160" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" (click)="onAspectClick(aspect)">
       <xhtml:div xmlns="http://www.w3.org/1999/xhtml">
         <app-summary-view [text]="aspect.name" [values$]="getData(aspect.id)" [clickable]="isClickable(aspect)"></app-summary-view>
       </xhtml:div>

--- a/src/app/apps/quap/components/graph-views/canton-graph-view/canton-graph-view.component.ts
+++ b/src/app/apps/quap/components/graph-views/canton-graph-view/canton-graph-view.component.ts
@@ -78,11 +78,11 @@ export class CantonGraphViewComponent implements OnInit, OnDestroy {
     return this.answerData[aspectId].asObservable();
   }
 
-  onAspectClick(index: number) {
-    if (!this.isClickable(this.aspects[index])) {
+  onAspectClick(aspect: Aspect) {
+    if (!this.isClickable(aspect)) {
       return;
     }
-    this.selectAspectEvent.emit(index);
+    this.selectAspectEvent.emit(aspect.id);
   }
 
   isClickable(aspect: Aspect): boolean {

--- a/src/app/apps/quap/components/graph-views/department-graph-view/department-graph-view.component.html
+++ b/src/app/apps/quap/components/graph-views/department-graph-view/department-graph-view.component.html
@@ -24,7 +24,7 @@
 
     <g id="graph" clip-path="url(#clip0)">
       <rect x="41.5" y="561.5" width="764" height="317" rx="28.5" fill="white" stroke="black" stroke-width="6"/>
-      <foreignObject *ngFor="let aspect of aspects; let i = index" [attr.x]="aspectMapping[aspect.id].x" [attr.y]="aspectMapping[aspect.id].y" width="320" height="160" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" (click)="onAspectClick(i)">
+      <foreignObject *ngFor="let aspect of aspects" [attr.x]="aspectMapping[aspect.id].x" [attr.y]="aspectMapping[aspect.id].y" width="320" height="160" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" (click)="onAspectClick(aspect)">
         <xhtml:div xmlns="http://www.w3.org/1999/xhtml">
           <app-summary-view [text]="aspect.name" [values$]="getData(aspect.id)" [clickable]="isClickable(aspect)"></app-summary-view>
         </xhtml:div>

--- a/src/app/apps/quap/components/graph-views/department-graph-view/department-graph-view.component.ts
+++ b/src/app/apps/quap/components/graph-views/department-graph-view/department-graph-view.component.ts
@@ -95,11 +95,11 @@ export class DepartmentGraphViewComponent implements OnInit, OnDestroy {
     return this.answerData[aspectId].asObservable();
   }
 
-  onAspectClick(index: number) {
-    if (!this.isClickable(this.aspects[index])) {
+  onAspectClick(aspect: Aspect) {
+    if (!this.isClickable(aspect)) {
       return;
     }
-    this.selectAspectEvent.emit(index);
+    this.selectAspectEvent.emit(aspect.id);
   }
 
   isClickable(aspect: Aspect): boolean {

--- a/src/app/apps/quap/components/graph-views/graph-container/graph-container.component.ts
+++ b/src/app/apps/quap/components/graph-views/graph-container/graph-container.component.ts
@@ -6,7 +6,6 @@ import {AnswerOption, AnswerStack} from '../../../models/question';
 import {CalculationHelper} from '../../../services/calculation.helper';
 import {AnswerState} from '../../../state/answer.state';
 import {QuestionnaireState} from '../../../state/questionnaire.state';
-import {GroupFacade} from '../../../../../store/facade/group.facade';
 import {takeUntil} from 'rxjs/operators';
 import {Subject} from 'rxjs';
 import {GroupType} from '../../../../../shared/models/group-type';
@@ -31,7 +30,7 @@ export class GraphContainerComponent implements OnInit, OnDestroy, DialogControl
   validatedAnswers: AnswerStack;
 
   private selectedAspects: Aspect[] = [];
-  private selectedIndex: number|null;
+  private selectedAspectId: number|null;
   private currentDialogOrigin: string|null;
 
   private destroyed$ = new Subject();
@@ -100,9 +99,9 @@ export class GraphContainerComponent implements OnInit, OnDestroy, DialogControl
     return 'overview';
   }
 
-  openEvaluationDialog(index?: number, origin?: string): void {
-    if (index !== undefined) {
-      this.selectedAspects = [ this.questionnaire.aspects[index] ];
+  openEvaluationDialog(aspectId?: number, origin?: string): void {
+    if (aspectId !== undefined) {
+      this.selectedAspects = [ this.getAspectById(aspectId) ];
     } else {
       this.selectedAspects = [];
     }
@@ -113,10 +112,10 @@ export class GraphContainerComponent implements OnInit, OnDestroy, DialogControl
     this.dialogService.addDialogController(this);
   }
 
-  openDetailDialog(index?: number, origin?: string): void {
-    this.selectedIndex = index;
-    if (index !== undefined) {
-      this.selectedAspects = [ this.questionnaire.aspects[index] ];
+  openDetailDialog(aspectId?: number, origin?: string): void {
+    this.selectedAspectId = aspectId;
+    if (aspectId !== undefined) {
+      this.selectedAspects = [ this.getAspectById(aspectId) ];
     } else {
       this.selectedAspects = [];
     }
@@ -145,10 +144,10 @@ export class GraphContainerComponent implements OnInit, OnDestroy, DialogControl
     if ('goto' in result) {
       switch (result.goto.to) {
         case 'evaluation':
-          this.openEvaluationDialog(this.selectedIndex, result.goto.from);
+          this.openEvaluationDialog(this.selectedAspectId, result.goto.from);
           break;
         case 'detail':
-          this.openDetailDialog(this.selectedIndex, result.goto.from);
+          this.openDetailDialog(this.selectedAspectId, result.goto.from);
           break;
         default:
           // goto overview
@@ -157,16 +156,20 @@ export class GraphContainerComponent implements OnInit, OnDestroy, DialogControl
     } else if ('returnTo' in result) {
       switch (result.returnTo) {
         case 'evaluation':
-          this.openEvaluationDialog(this.selectedIndex);
+          this.openEvaluationDialog(this.selectedAspectId);
           break;
         case 'detail':
-          this.openDetailDialog(this.selectedIndex);
+          this.openDetailDialog(this.selectedAspectId);
           break;
         default:
           // goto overview
           break;
       }
     }
+  }
+
+  getAspectById(aspectId: number): Aspect {
+    return this.questionnaire.aspects.find(aspect => aspect.id === aspectId)
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
### Issue 

When clicking on the " Werbung " aspect, a pop-up opens for the “Stufengerechtes Program” aspect. This happens for other aspects as well.

![image](https://github.com/user-attachments/assets/065f2ef2-9538-44e3-a821-cec7e0644972)

### Cause

The fix for #97 introduced the unwanted bug. Removing aspects that aren't needed for display in one part of the application causes problems because the aspects are passed by index throughout the application.
### Fix

By refactoring the quap logic to pass the aspects by aspectID instead of the index of the aspects array, the problem is solved.
