### PR TITLE
Gamification Improvements

### DIFF
--- a/src/app/gamification/level-card/level-card.component.html
+++ b/src/app/gamification/level-card/level-card.component.html
@@ -1,9 +1,12 @@
 <div class="gamification-card">
   <div class="header" (click)="toggleOpen()">
-    <div class="title">
-      <i [ngClass]="{'rotate': level.active}" class="icon-arrow-small-down"></i>
-      <p>{{level.title}}</p>
-      <p style="font-weight: normal;">{{'gamification.required' | translate : {amount: level.required} }}</p>
+    <div style="display: flex; flex-direction: column; gap: 2px;">
+      <div class="title">
+        <i [ngClass]="{'rotate': level.active}" class="icon-arrow-small-down"></i>
+        <p class="role">{{level.title}}</p>
+        <p>{{'gamification.required' | translate : {amount: level.required} }}</p>
+      </div>
+      <p *ngIf="level.access" style="padding-left: 2px; font-size: small; color: #8B8B8B;">{{ level.access }}</p>
     </div>
     <app-level-progress [segments]="level.goals.length" [required]="level.required" [completed]="getAmountCompleted()" [progressing]="getAmountProgressing()" [levelComplete]="isComplete"></app-level-progress>
   </div>

--- a/src/app/gamification/level-card/level-card.component.scss
+++ b/src/app/gamification/level-card/level-card.component.scss
@@ -14,10 +14,11 @@
       display: flex;
       gap: 8px;
     }
-    p, i {
+    .role {
       font-weight: 800;
     }
     i {
+      font-weight: 800;
       scale: 0.7;
       translate: 6px -1px;
       rotate: -90deg;

--- a/src/app/gamification/personal-profile/personal-profile.component.html
+++ b/src/app/gamification/personal-profile/personal-profile.component.html
@@ -2,6 +2,6 @@
 <div *ngIf="!loading" class="gamification-wrapper">
   <app-person-header [title]="gamification.title"></app-person-header>
   <app-level-card *ngFor="let level of gamification.levels" [level]="level" [isComplete]="isLevelComplete(level)"></app-level-card>
-  <button (click)="resetGamification()">TESTING: reset gamification <app-info position="bottom-right" iconClass="icon-info" rawMessage="Dieser Button löscht dein Gamification Profil und ist nicht umkehrbar! Nach dem Zurücksetzen hast du ein neues Profil ohne jeglichen Fortschritt. (Ausnahme: Logins)"></app-info></button>
+  <button *ngIf="resetEnabled" (click)="resetGamification()">TESTING: reset gamification <app-info position="bottom-right" iconClass="icon-info" rawMessage="Dieser Button löscht dein Gamification Profil und ist nicht umkehrbar! Nach dem Zurücksetzen hast du ein neues Profil ohne jeglichen Fortschritt. (Ausnahme: Logins)"></app-info></button>
 </div>
 <app-gamification-popup *ngIf="!loading && levelUp" [title]="gamification.title" (closePopup)="closeLevelUp()"></app-gamification-popup>

--- a/src/app/gamification/personal-profile/personal-profile.component.ts
+++ b/src/app/gamification/personal-profile/personal-profile.component.ts
@@ -3,6 +3,7 @@ import {GamificationFacade} from '../../store/facade/gamification.facade';
 import {GamificationLevel, PersonalGamification} from '../../shared/models/gamification';
 import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
 
 @Component({
   selector: 'app-personal-profile',
@@ -43,5 +44,9 @@ export class PersonalProfileComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.destroyed$.next(true);
     this.destroyed$.complete();
+  }
+
+  get resetEnabled(): boolean {
+    return environment.gamification.resetEnabled
   }
 }

--- a/src/app/shared/components/info/info.component.scss
+++ b/src/app/shared/components/info/info.component.scss
@@ -26,6 +26,7 @@ $gray: gray;
     pointer-events: none;
     color: white;
     z-index: 200;
+    white-space: pre-line;
 
     &.bottom {
       top: 24px;

--- a/src/app/shared/models/gamification.ts
+++ b/src/app/shared/models/gamification.ts
@@ -13,6 +13,7 @@ export interface GamificationLevel {
   title: string;
   active: boolean;
   required: number;
+  access?: string;
 }
 
 export interface GamificationGoal {

--- a/src/app/store/facade/gamification.facade.ts
+++ b/src/app/store/facade/gamification.facade.ts
@@ -1,16 +1,10 @@
 import {Injectable} from '@angular/core';
-import {WidgetState} from '../state/widget.state';
-import {WidgetService} from '../services/widget.service';
-import {map, take} from 'rxjs/operators';
-import {BehaviorSubject, combineLatest, Observable, Subject, Subscription} from 'rxjs';
-import {Widget} from '../../shared/models/widget';
-import {DateSelection} from '../../shared/models/date-selection/date-selection';
-import {Group} from '../../shared/models/group';
-import {CensusFilterService, CensusFilterState} from '../services/census-filter.service';
+import {skipUntil} from 'rxjs/operators';
+import {BehaviorSubject, Observable} from 'rxjs';
+import {CensusFilterService} from '../services/census-filter.service';
 import {GamificationService} from '../services/gamification.service';
 import {ApiService} from '../../shared/services/api.service';
 import {GroupFacade} from './group.facade';
-import {Person} from '../../shared/models/person';
 import {DefaultFilterFacade} from './default-filter.facade';
 import {Router} from '@angular/router';
 import {PersonalGamification} from '../../shared/models/gamification';
@@ -31,9 +25,13 @@ export class GamificationFacade {
     private gamificationService: GamificationService,
     private groupFacade: GroupFacade,
     private filterFacade: DefaultFilterFacade,
+    private censusFilterService: CensusFilterService,
     private router: Router
   ) {
     this.filterFacade.getUpdates$().subscribe(this.gamificationService.logFilterChanges());
+      this.censusFilterService.getUpdates$().
+      pipe(skipUntil(this.censusFilterService.isInitialized$())).
+      subscribe(this.gamificationService.logCensusFilterChanges());
   }
 
   gotoProfile() {

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -8,5 +8,8 @@ export const environment = {
     redirectUri: 'https://hc-dev.cust.digio.ch/callback',
     scope: 'email name with_roles',
   },
+  gamification: {
+    resetEnabled: true,
+  },
   version: '1.5.0'
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -8,5 +8,8 @@ export const environment = {
     redirectUri: 'https://hc.scout.ch/callback',
     scope: 'email name with_roles',
   },
+  gamification: {
+    resetEnabled: false,
+  },
   version: '1.5.0'
 };

--- a/src/environments/environment.stage.ts
+++ b/src/environments/environment.stage.ts
@@ -8,5 +8,8 @@ export const environment = {
     redirectUri: 'https://hc-stage.cust.digio.ch/callback',
     scope: 'email name with_roles',
   },
+  gamification: {
+    resetEnabled: true,
+  },
   version: '1.5.0'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -12,6 +12,9 @@ export const environment = {
     redirectUri: 'http://localhost:4200/callback',
     scope: 'email name with_roles',
   },
+  gamification: {
+    resetEnabled: true,
+  },
   version: '1.5.0'
 };
 


### PR DESCRIPTION
- added a gamification trigger when changing the census filter
- added line break support in the popups on the profile page
- displayed the level access next to the levels
> Level Access: Describes the needed permissions to be able to solve the tasks of a level
- disabled gamification reset functionality for production
